### PR TITLE
修复一个bug，mongodb驱动在读数据库生成Component对象时有可能会是在其它线程调用，并且会调用Component的无参构造函数

### DIFF
--- a/Unity/Assets/Scripts/Base/Object/Component.cs
+++ b/Unity/Assets/Scripts/Base/Object/Component.cs
@@ -6,6 +6,7 @@ namespace ETModel
 	[BsonIgnoreExtraElements]
 	public abstract class Component : Object, IDisposable, IComponentSerialize
 	{
+		// 只有Game.EventSystem.Add方法中会设置该值，如果new出来的对象不想加入Game.EventSystem中，则需要自己在构造函数中设置
 		[BsonIgnore]
 		public long InstanceId { get; protected set; }
 
@@ -28,11 +29,7 @@ namespace ETModel
 					return;
 				}
 
-				if (this.InstanceId == 0)
-				{
-					this.InstanceId = IdGenerater.GenerateId();
-				}
-
+				this.InstanceId = IdGenerater.GenerateId();
 				Game.EventSystem.Add(this);
 			}
 		}
@@ -65,7 +62,6 @@ namespace ETModel
 		
 		protected Component()
 		{
-			this.InstanceId = IdGenerater.GenerateId();
 		}
 
 		public virtual void Dispose()
@@ -79,7 +75,7 @@ namespace ETModel
 			Game.EventSystem.Destroy(this);
 
 			Game.EventSystem.Remove(this.InstanceId);
-
+			
 			this.InstanceId = 0;
 
 			if (this.IsFromPool)

--- a/Unity/Assets/Scripts/Base/Object/EventSystem.cs
+++ b/Unity/Assets/Scripts/Base/Object/EventSystem.cs
@@ -197,9 +197,9 @@ namespace ETModel
 			}
 		}
 
-		public void Remove(long id)
+		public void Remove(long instanceId)
 		{
-			this.allComponents.Remove(id);
+			this.allComponents.Remove(instanceId);
 		}
 
 		public Component Get(long id)

--- a/Unity/Assets/Scripts/Module/Message/ErrorCode.cs
+++ b/Unity/Assets/Scripts/Module/Message/ErrorCode.cs
@@ -4,6 +4,8 @@ namespace ETModel
 	{
 		public const int ERR_Success = 0;
 		
+		// 1-11004 是SocketError请看SocketError定义
+		
 		// 100000 以上，避免跟SocketError冲突
 		public const int ERR_MyErrorCode = 100000;
 		

--- a/Unity/Assets/Scripts/Module/Message/Network/AChannel.cs
+++ b/Unity/Assets/Scripts/Module/Message/Network/AChannel.cs
@@ -5,15 +5,6 @@ using System.Net;
 
 namespace ETModel
 {
-	[Flags]
-	public enum PacketFlags
-	{
-		None = 0,
-		Reliable = 1 << 0,
-		Unsequenced = 1 << 1,
-		NoAllocate = 1 << 2
-	}
-
 	public enum ChannelType
 	{
 		Connect,

--- a/Unity/Assets/Scripts/Module/Message/Network/KCP/KChannel.cs
+++ b/Unity/Assets/Scripts/Module/Message/Network/KCP/KChannel.cs
@@ -43,6 +43,8 @@ namespace ETModel
 		// accept
 		public KChannel(uint conn, uint remoteConn, Socket socket, IPEndPoint remoteEndPoint, KService kService) : base(kService, ChannelType.Accept)
 		{
+			this.InstanceId = IdGenerater.GenerateId();
+			
 			this.Id = conn;
 			this.Conn = conn;
 			this.RemoteConn = remoteConn;
@@ -61,6 +63,8 @@ namespace ETModel
 		// connect
 		public KChannel(uint conn, Socket socket, IPEndPoint remoteEndPoint, KService kService) : base(kService, ChannelType.Connect)
 		{
+			this.InstanceId = IdGenerater.GenerateId();
+			
 			this.Id = conn;
 			this.Conn = conn;
 			this.socket = socket;

--- a/Unity/Assets/Scripts/Module/Message/Network/TCP/TChannel.cs
+++ b/Unity/Assets/Scripts/Module/Message/Network/TCP/TChannel.cs
@@ -27,6 +27,8 @@ namespace ETModel
 
 		public TChannel(IPEndPoint ipEndPoint, TService service): base(service, ChannelType.Connect)
 		{
+			this.InstanceId = IdGenerater.GenerateId();
+			
 			this.socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
 			this.socket.NoDelay = true;
 			this.parser = new PacketParser(this.recvBuffer);
@@ -41,6 +43,8 @@ namespace ETModel
 		
 		public TChannel(Socket socket, TService service): base(service, ChannelType.Accept)
 		{
+			this.InstanceId = IdGenerater.GenerateId();
+			
 			this.socket = socket;
 			this.socket.NoDelay = true;
 			this.parser = new PacketParser(this.recvBuffer);

--- a/Unity/Hotfix/Base/Object/Component.cs
+++ b/Unity/Hotfix/Base/Object/Component.cs
@@ -6,6 +6,7 @@ namespace ETHotfix
 	[BsonIgnoreExtraElements]
 	public abstract class Component : Object, IDisposable, IComponentSerialize
 	{
+		// 只有Game.EventSystem.Add方法中会设置该值，如果new出来的对象不想加入Game.EventSystem中，则需要自己在构造函数中设置
 		[BsonIgnore]
 		public long InstanceId { get; protected set; }
 
@@ -28,11 +29,7 @@ namespace ETHotfix
 					return;
 				}
 
-				if (this.InstanceId == 0)
-				{
-					this.InstanceId = IdGenerater.GenerateId();
-				}
-
+				this.InstanceId = IdGenerater.GenerateId();
 				Game.EventSystem.Add(this);
 			}
 		}
@@ -65,7 +62,6 @@ namespace ETHotfix
 
 		protected Component()
 		{
-			this.InstanceId = IdGenerater.GenerateId();
 		}
 		
 		public virtual void Dispose()


### PR DESCRIPTION
而Component中的无参构造函数分配了一个id，但是这个id生成器不是线程安全的，所以这个id不能在这里分配，这里将其去掉。

有两种情况：
1.使用ComponentFactory创建Component，这些工厂方法会从对象池取出Component，这里会设置好InstanceId。
2.如果某些时候，组件不想使用对象池并且不想使用System事件，那么这时候会自己new Component，假如这个组件也需要InstanceId，
那么需要自己在构造函数中去设置InstanceId